### PR TITLE
Update RecordFragment.java . Parent directories will be made i.e. Music/SoundRecorder

### DIFF
--- a/app/src/main/java/by/naxa/soundrecorder/fragments/RecordFragment.java
+++ b/app/src/main/java/by/naxa/soundrecorder/fragments/RecordFragment.java
@@ -351,7 +351,7 @@ public class RecordFragment extends Fragment {
         );
         if (!folder.exists()) {
             // a folder for sound recordings doesn't exist -> create the folder
-            boolean ok = Paths.isExternalStorageWritable() && folder.mkdir();
+            boolean ok = Paths.isExternalStorageWritable() && folder.mkdirs();
             if (!ok) {
                 EventBroadcaster.send(getContext(), R.string.error_mkdir);
                 return false;


### PR DESCRIPTION
If Music directory is not in your storage you will get following error.
**Error! External storage (SD card) is not available for writing.**
Because of mkdir() in the following code of RecordFragment.java in startFragment() function
` if (!folder.exists()) {
            // a folder for sound recordings doesn't exist -> create the folder
            boolean ok = Paths.isExternalStorageWritable() && folder.mkdirs();
            if (!ok) {
                EventBroadcaster.send(getContext(), R.string.error_mkdir);
                return false;
            }
        }`
i replaced mkdir with mkdirs() which will also create parent directories